### PR TITLE
Replace FxCopAnalyzers with NetAnalyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,13 +15,7 @@
     <NoWarn>NU5105</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>5.0</LangVersion>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019

Supersedes #22